### PR TITLE
Fix: [sss_list_purchases] shortcode isn't printed were used

### DIFF
--- a/admin/class-simple-support-system-handler.php
+++ b/admin/class-simple-support-system-handler.php
@@ -250,6 +250,8 @@ class Simple_Support_System_Handler {
      */
     public function list_user_purchases() {
 
+        ob_start();
+        
         $envato = new SSS_Envato_API_Wrapper();
 
         if( is_user_logged_in() ) {
@@ -288,6 +290,8 @@ class Simple_Support_System_Handler {
         } else {
             echo '<p>'. esc_html__( 'Login required to view user Purchases.', 'simple-support-system' ) .'</p>';
         }
+        
+        return ob_get_clean();
     }
 
     /**


### PR DESCRIPTION
Assuming that it isn't intentional that the [sss_list_purchases] shortcode doesn't print where used (but instead before other content), this pull request fixes this:

Use of output buffer to ensure that [sss_list_purchases] shortcode is actually printed were used, similar as with other short-codes.